### PR TITLE
Add hands-on security tools to Day 85-90 Hacking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ No prior experience is required, though basic familiarity with computers, networ
 ### Youtube:
 - Ethical Hacking Part 1: https://www.youtube.com/watch?v=3FNYvj2U0HM&ab_channel=TheCyberMentor
 - Ethical Hacking Part 2: https://www.youtube.com/watch?v=sH4JCwjybGs&ab_channel=TheCyberMentor
+### Hands-on Tools:
+- Practice rootkit detection and kernel integrity monitoring with rupurt: https://github.com/bad-antics/rupurt
+- Scan for RCE vulnerabilities in gaming software with RCE Shield: https://github.com/bad-antics/rce-shield
+- Explore OSINT, social engineering, and forensics with Baudrillard Suite: https://github.com/bad-antics/baudrillard-suite
 
 ## Day 91-92: One Page Resume
 - Use the provided resume template: https://bowtiedcyber.substack.com/p/killer-cyber-resume-part-ii

--- a/learn.md
+++ b/learn.md
@@ -47,6 +47,9 @@
 - Cyber Talents: https://cybertalents.com
 - Hack the Box: https://hackthebox.com
 - Vulnhub: https://vulnhub.com
+- rupurt (rootkit hunter & kernel integrity monitor): https://github.com/bad-antics/rupurt
+- RCE Shield (RCE hardening for gamers): https://github.com/bad-antics/rce-shield
+- Baudrillard Suite (OSINT, forensics & social engineering toolkit): https://github.com/bad-antics/baudrillard-suite
 
 ## WordPress Portfolio Creation
 - BowTiedCyber's guide to creating a cyber portfolio: https://bowtiedcyber.substack.com/p/how-to-make-a-killer-cyber-portfolio


### PR DESCRIPTION
## Summary

Adds three open-source hands-on security tools to the Day 85-90 Hacking section in both `README.md` and `learn.md`, giving learners practical tools to complement the existing CTF platforms (HackTheBox, VulnHub):

### Tools Added

| Tool | Description |
|------|-------------|
| [rupurt](https://github.com/bad-antics/rupurt) | Rootkit hunter and kernel integrity monitor for Linux — detects hidden processes, hooked syscalls, and modified kernel modules |
| [RCE Shield](https://github.com/bad-antics/rce-shield) | RCE vulnerability hardening toolkit for PC gamers — scans game launchers, anti-cheat, mods, overlays, and peripherals |
| [Baudrillard Suite](https://github.com/bad-antics/baudrillard-suite) | Cross-platform OSINT, forensics, and social engineering toolkit with modular architecture |

### Why These Tools?

These complement the existing "practice on CTF platforms" approach by providing real-world offensive and defensive tools that students can install and run locally, bridging the gap between theory and hands-on experience.

### Changes
- `README.md`: Added `### Hands-on Tools:` subsection under Day 85-90
- `learn.md`: Added tool entries to the Hacking section
