### PR TITLE
Add interactive version link to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ The daily modules cover essential and advanced topics, including:
 - Penetration testing and ethical hacking
 
 Each day is designed with actionable tasks, tutorials, and reading materials to help you stay on track. For a full list of resources, refer to [`learn.md`](./learn.md).
+## 🚀 Interactive Version Available!
 
+Prefer a visual, clickable interface? Try the community-built **[Interactive 90-Day Cybersecurity Roadmap](https://github.com/MOUKA-513/90DaysOfCyberSecurity-Interactive)** — filter by phase, track your progress, and access all resources in one place.
+
+👉 **[Launch Live Demo](https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/)**
 ## 🎯 Goals and Audience
 
 ### 📌 Goals

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Before using any AI CLI, redact sensitive personal data in `cv.md` (for example 
 2. **Evaluate (Day 94):** paste 10-20 postings you found on Indeed or LinkedIn. Only apply to roles that score 4.0/5 or higher; treat it as a filter, not a spray-and-pray tool.
 3. **Apply and prepare (Day 95):** generate tailored CVs for your shortlist, apply, and use the interview-prep mode to build your STAR stories before the first call.
 
+## 🔗 Community Projects
+
+
+- [Interactive 90-Day Cybersecurity Roadmap](https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/) by @MOUKA-513 — filter by phase and open every resource from one page ([source](https://github.com/MOUKA-513/90DaysOfCyberSecurity-Interactive)).
 
 
 ## Translations

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - Bonus: Landing the Job
   - [Day 91-92: One Page Resume](#day-91-92-one-page-resume)
   - [Day 93-95: Where and How to Apply](#day-93-95-where-and-how-to-apply)
+- [Community Projects](#-community-projects)
 - [Translations](#translations)
 - [Contributors](#-contributors)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - Bonus: Landing the Job
   - [Day 91-92: One Page Resume](#day-91-92-one-page-resume)
   - [Day 93-95: Where and How to Apply](#day-93-95-where-and-how-to-apply)
-- [Community Projects](#-community-projects)
+- [Community Projects](#community-projects)
 - [Translations](#translations)
 - [Contributors](#-contributors)
 
@@ -198,10 +198,11 @@ Before using any AI CLI, redact sensitive personal data in `cv.md` (for example 
 2. **Evaluate (Day 94):** paste 10-20 postings you found on Indeed or LinkedIn. Only apply to roles that score 4.0/5 or higher; treat it as a filter, not a spray-and-pray tool.
 3. **Apply and prepare (Day 95):** generate tailored CVs for your shortlist, apply, and use the interview-prep mode to build your STAR stories before the first call.
 
-## 🔗 Community Projects
+## Community Projects
 
-- [Interactive 90-Day Cybersecurity Roadmap](https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/) by [@MOUKA-513](https://github.com/MOUKA-513) — filter by phase and open every resource from one page ([source](https://github.com/MOUKA-513/90DaysOfCyberSecurity-Interactive)).
+Awesome community-built tools and resources that complement the 90-day plan:
 
+- [Interactive 90-Day Cybersecurity Roadmap](https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/) by [@MOUKA-513](https://github.com/MOUKA-513) — Interactive web-based roadmap that lets you filter by phase and open every resource from one page ([source](https://github.com/MOUKA-513/90DaysOfCyberSecurity-Interactive))
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -199,8 +199,7 @@ Before using any AI CLI, redact sensitive personal data in `cv.md` (for example 
 
 ## 🔗 Community Projects
 
-
-- [Interactive 90-Day Cybersecurity Roadmap](https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/) by @MOUKA-513 — filter by phase and open every resource from one page ([source](https://github.com/MOUKA-513/90DaysOfCyberSecurity-Interactive)).
+- [Interactive 90-Day Cybersecurity Roadmap](https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/) by [@MOUKA-513](https://github.com/MOUKA-513) — filter by phase and open every resource from one page ([source](https://github.com/MOUKA-513/90DaysOfCyberSecurity-Interactive)).
 
 
 ## Translations


### PR DESCRIPTION
## What I Added
- Link to the interactive version of this roadmap that I built
- It provides a filterable UI and one-click resource access
- Live demo: https://MOUKA-513.github.io/90DaysOfCyberSecurity-Interactive/

This gives learners an alternative way to navigate the curriculum.

I'd also like to be added as a contributor for this addition. I'll use the all-contributors bot after merge.

Thanks for the awesome roadmap!